### PR TITLE
Address nan error in create_config

### DIFF
--- a/src/simmer/create_config.py
+++ b/src/simmer/create_config.py
@@ -8,9 +8,10 @@ import pandas as pd
 
 class LogsheetError(ValueError):
     """
-    For incorrect values within a logsheet that 
+    For incorrect values within a logsheet that
     can break `create_config` with opaque error messages.
     """
+
     pass
 
 
@@ -51,7 +52,9 @@ def create_config(log, config_file, tab=None):
         start = logdf["Start"].iloc[row]
         end = logdf["End"].iloc[row]
         if np.isnan(start) or np.isnan(end):
-            raise LogsheetError(f'Check for empty start or end entry in row {row}.')
+            raise LogsheetError(
+                f"Check for empty start or end entry in row {row}."
+            )
         filelist = range(start, end + 1)
         filenums.append(filelist)
 

--- a/src/simmer/create_config.py
+++ b/src/simmer/create_config.py
@@ -2,14 +2,14 @@
 Creates config file from logsheet. Will move into either utils or example folder.
 """
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 class LogsheetError(ValueError):
-    ""
+    """
     For incorrect values within a logsheet that 
     can break `create_config` with opaque error messages.
-    ""
+    """
     pass
 
 

--- a/src/simmer/create_config.py
+++ b/src/simmer/create_config.py
@@ -5,6 +5,7 @@ Creates config file from logsheet. Will move into either utils or example folder
 import numpy as np
 import pandas as pd
 
+
 class LogsheetError(ValueError):
     """
     For incorrect values within a logsheet that 

--- a/src/simmer/create_config.py
+++ b/src/simmer/create_config.py
@@ -3,6 +3,14 @@ Creates config file from logsheet. Will move into either utils or example folder
 """
 
 import pandas as pd
+import numpy as np
+
+class LogsheetError(ValueError):
+    ""
+    For incorrect values within a logsheet that 
+    can break `create_config` with opaque error messages.
+    ""
+    pass
 
 
 def create_config(log, config_file, tab=None):
@@ -41,6 +49,8 @@ def create_config(log, config_file, tab=None):
     for row in range(0, nrows):
         start = logdf["Start"].iloc[row]
         end = logdf["End"].iloc[row]
+        if np.isnan(start) or np.isnan(end):
+            raise LogsheetError(f'Check for empty start or end entry in row {row}.')
         filelist = range(start, end + 1)
         filenums.append(filelist)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- inspired by TARDIS: https://github.com/tardis-sn/tardis/edit/master/.github/PULL_REQUEST_TEMPLATE.md --->

## Description
<!--- Describe your changes in detail -->
NaN errors can get thrown if there are empty cells in the logsheet when calling create_config. This guards against that with a new exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
N/A


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
