### PR TITLE
only reduce stars that are in the config file

### DIFF
--- a/src/simmer/drivers.py
+++ b/src/simmer/drivers.py
@@ -43,9 +43,17 @@ def all_driver(inst, config_file, raw_dir, reddir, plotting_yml=None):
     methods = image.image_driver(raw_dir, reddir, config, inst)
 
     star_dirlist = glob(reddir + "*/")
+
+    # we want to ensure that the code doesn't attempt to reduce folders
+    # that are in the reduced directory but not in the config
+    cleaned_star_dirlist = list(set(star_dirlist) & set(config.Object))
+
     i = 0  # can't use tqdm on zipped objects, I believe
     for s_dir in tqdm(
-        star_dirlist, desc="Running registration", position=0, leave=True
+        cleaned_star_dirlist,
+        desc="Running registration",
+        position=0,
+        leave=True,
     ):
         image.create_im(s_dir, 10, method=methods[i])
         i += 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- inspired by TARDIS: https://github.com/tardis-sn/tardis/edit/master/.github/PULL_REQUEST_TEMPLATE.md --->

## Description
<!--- Describe your changes in detail -->
I call create_im only on stars that are both in the config and have a folder in the reduced directory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If there happen to be any folders left over in the reduced directory from previous reduction attempts, nothing should go awry anymore. Fixes #43.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testing now!


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
