### PR TITLE
Improved validation & streamlining

### DIFF
--- a/src/simmer/add_dark_exp.py
+++ b/src/simmer/add_dark_exp.py
@@ -118,8 +118,10 @@ def add_dark_exp(inst, log, raw_dir, tab=None):
     exptime = []
     exposes = []
 
+    previous_itime = np.nan #setting to a value that can't possibly match a real exposure time.
     for i, (itime, file) in enumerate(zip(itimes, files)):
-        if itime not in exptime:
+        if itime != previous_itime:
+            previous_itime = itime
             exptime += [itime]
             starts += [get_number(file)]
             objects += ["dark"]
@@ -141,7 +143,7 @@ def add_dark_exp(inst, log, raw_dir, tab=None):
         "End": ends,
         "ExpTime": exptime,
 
-        #"Coadds": np.full(len(objects), np.nan),
+        "Coadds": np.full(len(objects), 1),
         "Expose": exposes,
         #"Total_tint": np.full(len(objects), np.nan),
         #"Filter": np.full(len(objects), np.nan),

--- a/src/simmer/drivers.py
+++ b/src/simmer/drivers.py
@@ -98,14 +98,6 @@ def all_driver(
 
     """
 
-    # get file list from config file
-    config = pd.read_csv(config_file)
-    config.Object = config.Object.astype(str)
-
-    darks.dark_driver(raw_dir, reddir, config, inst)
-    flats.flat_driver(raw_dir, reddir, config, inst)
-    sky.sky_driver(raw_dir, reddir, config, inst)
-
 
 def image_driver(inst, config_file, raw_dir, reddir):
     """

--- a/src/simmer/run_night.py
+++ b/src/simmer/run_night.py
@@ -59,5 +59,6 @@ def run_night(wantdate, add_darks=True, just_images=False, verbose=False, skip_r
     #Reduce the data!
     if skip_reduction == True:
         print('files exist')
+        return config_file
     else:
         drivers.all_driver(inst, config_file, rawdir, reddir, just_images=just_images)

--- a/src/simmer/validate_config.py
+++ b/src/simmer/validate_config.py
@@ -15,8 +15,9 @@ import os as os
 
 from . import utils as u
 
-def validate_config(config, raw_dir, inst):
-    print('inspecting directory: ', raw_dir)
+def validate_config(config, raw_dir, inst, verbose=False):
+    if verbose == True:
+        print('inspecting directory: ', raw_dir)
 
     objissues = 0
     expissues = 0
@@ -29,49 +30,70 @@ def validate_config(config, raw_dir, inst):
         for file in flist:
             head = pyfits.getheader(file)
             hkeys = np.array(list(head.keys()))
-            print('     ', os.path.basename(file), head['Object'], head['RA'], head['DEC'])
+            if verbose == True:
+                print('     ', os.path.basename(file), head['Object'], head['RA'], head['DEC'])
 
-            if (this.Object.casefold() != head['Object'].casefold()):
-                print('ISSUE! ', os.path.basename(file))
-                print('     Object mismatch')
-                print('     Object in header: ', head['Object'])
-                print('     Object in logsheet: ', this.Object)
-                print('     Pointing RA: ', head['RA'])
-                print('     Pointing Dec ', head['DEC'])
-                print('**************************')
+                #Check object for everything but flats
+            if np.logical_and(this.Object.casefold() != head['Object'].casefold(), this.Object.casefold() != 'flat'):
+                if verbose == True:
+                    print('ISSUE! ', os.path.basename(file))
+                    print('     Object mismatch')
+                    print('     Object in header: ', head['Object'])
+                    print('     Object in logsheet: ', this.Object)
+                    print('     Pointing RA: ', head['RA'])
+                    print('     Pointing Dec ', head['DEC'])
+                    print('**************************')
                 objissues += 1
+
+            #check object for flats
+            if this.Object.casefold() == 'flat':
+                if np.logical_and(np.logical_and(head['Object'].casefold() != 'flat',head['Object'].casefold() != 'flats'), np.logical_and(head['Object'].casefold().replace(" ","") != 'skyflat',head['Object'].casefold().replace(" ","") != 'domeflat')):
+                    if verbose == True:
+                        print('ISSUE! ', os.path.basename(file))
+                        print('     Object mismatch')
+                        print('     Object in header: ', head['Object'])
+                        print('     Object in logsheet: ', this.Object)
+                        print('     Pointing RA: ', head['RA'])
+                        print('     Pointing Dec ', head['DEC'])
+                        print('**************************')
+                    objissues += 1
 
             #Compare exposure times. ITIME0 is recorded in microseconds
             if (this.ExpTime != (head['ITIME0']/1e6)):
-                print('ISSUE! ', os.path.basename(file))
-                print('     ExpTime mismatch')
-                print('     ExpTime in header: ', head['ITIME0']/1e6)
-                print('     ExpTime in logsheet: ', this.ExpTime)
-                print('**************************')
+                if verbose == True:
+                    print('ISSUE! ', os.path.basename(file))
+                    print('     ExpTime mismatch')
+                    print('     ExpTime in header: ', head['ITIME0']/1e6)
+                    print('     ExpTime in logsheet: ', this.ExpTime)
+                    print('**************************')
                 expissues += 1
 
-                #Check filters for everything but darks
+                #Check filters for everything but darks & J+Ch4-1.2 images
             if this.Object != "dark":
-                if np.logical_and(this.Filter != head['FILT1NAM'], this.Filter != 'J+Ch4-1.2'):
-                    print('ISSUE! ', os.path.basename(file))
-                    print('     Filter mismatch')
-                    print('     Filters in header: ', head['FILT1NAM'],head['FILT2NAM'])
-                    print('     Filter in logsheet: ', this.Filter)
-                    print('**************************')
-                    filtissues += 1
-
-                #Check filters for J+Ch1.4
-                if this.Filter == 'J+Ch4-1.2':
-                    if np.logical_or(head['FILT1NAM'] != 'J', head['FILT2NAM'] != 'Ch4-1.2'):
+                if np.logical_and(this.Filter != head['FILT1NAM'], this.Filter.casefold().replace(" ","") != 'J+Ch4-1.2'.casefold()):
+                    if verbose == True:
                         print('ISSUE! ', os.path.basename(file))
                         print('     Filter mismatch')
                         print('     Filters in header: ', head['FILT1NAM'],head['FILT2NAM'])
                         print('     Filter in logsheet: ', this.Filter)
                         print('**************************')
+                    filtissues += 1
+
+                #Check filters for J+Ch1.4
+                if this.Filter.casefold().replace(" ","") == 'J+Ch4-1.2':
+                    if np.logical_or(head['FILT1NAM'] != 'J', head['FILT2NAM'] != 'Ch4-1.2'):
+                        if verbose == True:
+                            print('ISSUE! ', os.path.basename(file))
+                            print('     Filter mismatch')
+                            print('     Filters in header: ', head['FILT1NAM'],head['FILT2NAM'])
+                            print('     Filter in logsheet: ', this.Filter)
+                            print('**************************')
                         filtissues += 1
 
+    #always print the final summary
     print('#################################')
     print('SUMMARY')
     print('Object mismatches: ', objissues)
     print('Exptime mismatches: ', expissues)
     print('Filter mismatches: ', filtissues)
+    print('#################################')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- inspired by TARDIS: https://github.com/tardis-sn/tardis/edit/master/.github/PULL_REQUEST_TEMPLATE.md --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Corrects issue writing lists of dark frames to the config file when multiple sets of darks were obtained at the same exposure time. Previously, the code got confused if dark exposure times were repeated and separated by other files. 

drivers.py used to re-run the drivers for darks, skies, and flats after registration. Now the code doesn't repeat those steps. 

Improved validate_config.py so that "sky flats", "dome flats", "flat", and "flats" are all treated as matches to "flat" in the .csv file. Also made formatting of J+Ch4-1.2 matches more flexible.  

Added /verbose keyword to validate_config.py so that the code can be run more quietly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
